### PR TITLE
「投稿一覧」「ページネーション」「カテゴリー作成」「投稿作成」の機能作成

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,21 @@
+class CategoriesController < ApplicationController
+  def new
+    @category = Category.new
+  end
+
+  def create
+    @category = Category.new(category_params)
+
+    if @category.save
+      redirect_to new_category_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def category_params
+    params.require(:category).permit(:name)
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,49 @@
+class PostsController < ApplicationController
+  def index
+    @posts = Post.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+  end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save_with_category(post_params[:category_name])
+      redirect_to posts_path, flash: { success: "投稿を作成しました" }
+    else
+      flash.now[:danger] = "投稿を作成出来ませんでした"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @post = Post.find(params[:id])
+  end
+
+  def edit
+    @post = current_user.posts.find(params[:id])
+  end
+
+  def update
+    @post = current_user.posts.find(params[:id])
+    if @post.update(post_params)
+      redirect_to @post, flash: { success: "投稿を更新しました" }
+    else
+      flash.now[:danger] = "投稿を更新出来ませんでした"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    post = current_user.posts.find(params[:id])
+    post.destroy!
+    redirect_to posts_path, flash: { success: "投稿を削除しました" }, status: :see_other
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :content, :category_name, :image, :image_cache)
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,7 +4,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to new_user_path, success: "ログインしました"
+      redirect_back_or_to posts_path, success: "ログインしました"
     else
       flash.now[:danger] = "ログインに失敗しました"
       render "new", status: :unprocessable_entity

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,17 @@
+class Post < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :content, presence: true, length: { maximum: 65_535 }
+
+  attr_accessor :category_name
+
+  def save_with_category(category_name)
+    return unless category_name.present?
+
+    category = Category.find_or_create_by(name: category_name)
+    self.category = category
+    save
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,13 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :posts
   validates :name, presence: true, length: { maximum: 25 }
   validates :email, uniqueness: true, presence: true
   validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  def mine?(object)
+    id == object.user_id
+  end
 end

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:title, t('.title')) %>
+
+<div class="container">
+  <div class="card">
+    <div class="card-header">
+      カテゴリー作成
+    </div>
+    <div class="card-body">
+      <%= form_with model: @category do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+        <div class="mb-3">
+          <%= f.label :name %>
+          <%= f.text_field :name, class: 'form-control' %>
+        </div>
+
+        <div class="text-center my-8">
+          <%= f.submit t('.submit'), class: "btn btn-sm bg-primary-content w-1/4" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: post do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="mb-3">
+    <%= f.label :title %>
+    <%= f.text_field :title, class: 'form-control' %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :category_name %>
+    <%= f.text_field :category_name, class: 'form-control', value: @post.category_name || @post.category&.name %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :content %>
+    <%= f.text_area :content, class: 'form-control', rows: 5 %>
+  </div>
+
+  <div class="text-center my-8">
+    <%= f.submit t('.submit'), class: "btn btn-sm bg-primary-content w-1/4" %>
+  </div>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,26 @@
+<li id="<%= dom_id(post) %>">
+  <div>
+    <div><%= link_to post.title, post_path(post) %></div>
+  </div>
+
+  <div class="d-flex">
+    <div>
+      <%= link_to post.category.name, posts_path(category_name: post.category.name),class: "badge rounded-pill bg-primary text-decoration-none text-white" %>
+    </div>
+
+    <div class="ms-auto">
+      <% if current_user&.mine?(post) %>
+        <div class="text-end">
+          <%= link_to '編集', edit_post_path(post), class: 'btn btn-success btn-sm' %>
+          <%= link_to '削除',
+                      post_path(post),
+                      class: 'btn btn-danger btn-sm',
+                      method: :delete,
+                      data: { confirm: '削除します' } %>
+        </div>
+      <% end %>
+      <%= l post.created_at, format: :long %>
+    </div>
+  </div>
+  <hr>
+</li>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,16 @@
+<% content_for(:title, t('.title')) %>
+
+<div class="container pt-3">
+  <div class="row">
+    <div class="col-12">
+      <div class="row">
+        <% if @posts.present? %>
+          <%= render @posts %>
+        <% else %>
+          <div class="mb-3">投稿がありません</div>
+        <% end %>
+      </div>
+      <%= paginate @posts %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title, t('.title')) %>
+
+<div class="container">
+  <div class="card">
+    <div class="card-header">
+      ポスト作成
+    </div>
+    <div class="card-body">
+      <%= render 'form', post: @post %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,5 +9,7 @@
   <div class="flex-none ml-auto">
     <%= link_to t("header.profile"), '#', class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3" %>
     <%= link_to t("header.logout"), logout_path, class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3", data: { turbo_method: :delete } %>
+    <%= link_to t("header.profile"), new_post_path, class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3" %>
+    <%= link_to t("header.logout"), new_category_path, class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3" %>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,6 +31,7 @@ ja:
       title: 投稿一覧
     new:
       title: 投稿作成
+      submit: 投稿
     show:
       title: 投稿詳細
     edit:
@@ -38,6 +39,10 @@ ja:
   comments:
     placeholder:
       comment: コメント
+  categories:
+    new:
+      title: カテゴリー登録
+      submit: 登録
   header:
     login: ログイン
     logout: ログアウト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   root "static_pages#top"
   resources :users, only: %i[new create]
-
+  resources :posts, only: %i[index new create show edit update destroy]
+  resources :categories, only: %i[new create]
   get "login" => "user_sessions#new"
   post "login" => "user_sessions#create"
   delete "logout" => "user_sessions#destroy"

--- a/db/migrate/20240820104938_create_categories.rb
+++ b/db/migrate/20240820104938_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240820110229_create_posts.rb
+++ b/db/migrate/20240820110229_create_posts.rb
@@ -1,0 +1,13 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.string :title, null: false, limit: 255
+      t.string :image
+      t.text :content, null: false, limit: 65535
+      t.references :user, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_20_020430) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_20_110229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title", limit: 255, null: false
+    t.string "image"
+    t.text "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_posts_on_category_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -28,4 +47,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_20_020430) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name"
   end
+
+  add_foreign_key "posts", "categories"
+  add_foreign_key "posts", "users"
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :category do
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :post do
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Categories", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
投稿一覧機能を作成するつもりだったものの、シードを作るのが面倒でまとめて機能作成。
「投稿一覧」「ページネーション」「カテゴリー作成」「投稿作成」

※サイドメニューの配置も考慮が必要なため現段階でレイアウトはとてもざっくり。

◆投稿一覧
categoryとpostのテーブルとMVC作成。
postのdb:migrateをしたところ、categoryとの依存関係があるためまずそっちのテーブルが必要だった。
→先にcreate_categoriesを作ってから、create_postsを作りdb:migrateで解消

◆ページネーション
gemのkaminariは入れていたため、viewとindexアクションで少し手を加えただけ。
めちゃ簡単。kaminariのviewは未作成。
[kaminari](https://pikawaka.com/rails/kaminari)

◆カテゴリー
最初はカテゴリーの登録を別個で考えていたものの、投稿でカテゴリーを入力してそのカテゴリーがなければそのまま追加登録されるように変更。
→一応カテゴリーの登録画面は作成したものの、おそらく不要になる予定

◆投稿作成
updateアクションで使うことも考慮して、form送信後にバリデーションエラーだったとしても、送信内容が残るように、categoryはcategory_nameで送信。