### PR TITLE
サイドバーの作成 / フラッシュメッセージの編集 close #26

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,8 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-header {
-  /* ナビバーの高さに合わせたパディングを追加 */
-  @apply pb-16;
-}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
     if @post.save_with_category(post_params[:category_name])
       redirect_to posts_path, flash: { success: "投稿を作成しました" }
     else
-      flash.now[:danger] = "投稿を作成出来ませんでした"
+      flash.now[:info] = "投稿を作成出来ませんでした"
       render :new, status: :unprocessable_entity
     end
   end
@@ -30,7 +30,7 @@ class PostsController < ApplicationController
     if @post.update(post_params)
       redirect_to @post, flash: { success: "投稿を更新しました" }
     else
-      flash.now[:danger] = "投稿を更新出来ませんでした"
+      flash.now[:info] = "投稿を更新出来ませんでした"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,9 +4,9 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to posts_path, success: "ログインしました"
+      redirect_to posts_path, success: "ログインしました"
     else
-      flash.now[:danger] = "ログインに失敗しました"
+      flash.now[:info] = "ログインに失敗しました"
       render "new", status: :unprocessable_entity
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     if @user.save
       redirect_to root_path, flash: { success: "ユーザー登録に成功しました" }
     else
-      flash.now[:danger] = "ユーザー登録に失敗しました"
+      flash.now[:info] = "ユーザー登録に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,19 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener("turbo:load", function() {
+  var menuToggle = document.getElementById('menu-toggle');
+  var sideMenu = document.getElementById('side-menu');
+  var menuIcon = document.getElementById('menu-icon');
+  var closeIcon = document.getElementById('close-icon');
+
+  if (menuToggle) {
+    menuToggle.addEventListener('click', function() {
+      sideMenu.classList.toggle('translate-x-0');
+      sideMenu.classList.toggle('-translate-x-full');
+      menuIcon.classList.toggle('hidden');
+      closeIcon.classList.toggle('hidden');
+    });
+  }
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,21 +13,26 @@
     <!-- <link rel="apple-touch-icon" href="/icon.png"> -->
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-    <script src="https://kit.fontawesome.com/12b5d77523.js" crossorigin="anonymous"></script>
+    <link href="https://cdn.jsdelivr.net/npm/remixicon@4.3.0/fonts/remixicon.css"
+    rel="stylesheet"/>
   </head>
 
 
-  <body>
+  <body class="relative">
     <header>
       <% if logged_in? %>
         <%= render "shared/header" %>
       <% else %>
         <%= render "shared/before_login_header" %>
       <% end %>
+      <%= render "shared/flash_message" %>
     </header>
 
-    <main>
-      <%= render "shared/flash_message" %>
+    <aside id="side-menu" class="fixed top-10 left-0 w-1/3 h-full bg-base-200 transform -translate-x-full transition-transform duration-300 z-40">
+      <%= render "shared/sidebar" %>
+    </aside>
+
+    <main class="flex flex-1 pb-4 z-10 ">
       <%= yield %>
     </main>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,21 +1,21 @@
 <%= form_with model: post do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="mb-3">
-    <%= f.label :title %>
+    <%= f.label :title, "タイトル" %>
     <%= f.text_field :title, class: 'form-control' %>
   </div>
 
   <div class="mb-3">
-    <%= f.label :category_name %>
+    <%= f.label :category_name, "カテゴリー" %>
     <%= f.text_field :category_name, class: 'form-control', value: @post.category_name || @post.category&.name %>
   </div>
 
   <div class="mb-3">
-    <%= f.label :content %>
+    <%= f.label :content, "内容" %>
     <%= f.text_area :content, class: 'form-control', rows: 5 %>
   </div>
 
   <div class="text-center my-8">
-    <%= f.submit t('.submit'), class: "btn btn-sm bg-primary-content w-1/4" %>
+    <%= f.submit t('helpers.submit.post'), class: "btn btn-sm bg-primary-content w-1/4" %>
   </div>
 <% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-300 fixed">
+<div class="navbar bg-base-300 sticky py-0 md:py-4 z-50">
   <div class="flex-1 ml-2">
     <div class="btn btn-ghost">
       <%= link_to root_path do %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,10 +1,10 @@
 <% if object.errors.any? %>
-  <div class= "alert alert-error py-2 mt-6", role="alert" >
+  <div class= "alert bg-custom-2 py-2", role="alert" >
     <ul>
       <% object.errors.each do |error| %>
         <li class="text-sm md:text-base"><%= error.full_message %></li>
       <% end %>
     </ul>
   </div>
-  <div class="border-b-2">&nbsp;</div>
+  <div class="divider pb-0 mb-0"></div>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,7 @@
-<% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>">
-    <%= message %>
-  </div>
-<% end %>
+<div class="relative">
+  <% flash.each do |message_type, message| %>
+    <div class="animate-flash rounded-md z-20 alert alert-<%= message_type %> fixed">
+      <%= message %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="footer justify-end bg-base-content text-base-content p-1 mt-2">
+<div class="footer fixed bottom-0 justify-end bg-base-content text-base-content p-1 z-50">
   <aside class="grid-flow-col items-center">
     <%= link_to t("footer.privacy_policy"), "#", class: "text-white" %>
     <%= link_to t("footer.terms_of_service"), "#", class: "text-white mx-4" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,14 @@
-<div class="navbar bg-base-300 fixed">
+<div class="navbar bg-base-300 sticky z-50 flex items-center justify-between">
+  <!-- ハンバーガーメニューのボタン -->
+  <button id="menu-toggle" class="btn btn-ghost">
+    <svg id="menu-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
+    </svg>
+    <svg id="close-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+    </svg>
+  </button>
+
   <div class="flex-1 ml-2">
     <div class="btn btn-ghost">
       <%= link_to root_path do %>
@@ -9,7 +19,5 @@
   <div class="flex-none ml-auto">
     <%= link_to t("header.profile"), '#', class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3" %>
     <%= link_to t("header.logout"), logout_path, class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3", data: { turbo_method: :delete } %>
-    <%= link_to t("header.profile"), new_post_path, class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3" %>
-    <%= link_to t("header.logout"), new_category_path, class: "btn btn-ghost font-thin text-xs md:text-base px-2 md:mx-3" %>
   </div>
 </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,0 +1,30 @@
+<div class="w-full h-vh-100 bg-base-200 mt-10">
+  <ul class="menu text-xl md:text-2xl font-thin m-6">
+    <li class="mb-4">
+      <%= link_to posts_path do %>
+        <i class="ri-star-line"></i>
+        <%= t("sidebar.index") %>
+      <% end %>
+    </li>
+    <li class="mb-4">
+      <%= link_to new_post_path do %>
+        <i class="ri-pencil-line"></i>
+        <%= t("sidebar.new") %>
+      <% end %>
+    </li>
+    <li class="mb-4">
+      <%= link_to "#" do %>
+        <i class="ri-heart-line"></i>
+        <%= t("sidebar.favorite") %>
+      <% end %>
+    </li>
+    <li class="mb-4">
+      <%= link_to "#" do %>
+        <i class="ri-search-2-line"></i>
+        <%= t("sidebar.search") %>
+      <% end %>
+    </li>
+    <div class="md:divider"></div>
+  </ul>
+</div>
+<i class="ri-heart-line"></i>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,21 +1,21 @@
 <% content_for(:title, t('.title')) %>
 
-<div class="container mx-auto" >
+<div class="container mx-auto mt-10" >
   <div class="flex justify-center">
     <div class="flex-grow max-w-64 md:max-w-md">
       <%= form_with url: login_path do |form| %>
-        <div class="py-8">
+        <div class="py-8 md:mb-8">
           <%= form.label :email, "メールアドレス" %>
           <%= form.text_field :email, class: "input input-bordered input-xs w-full" %>
         </div>
 
-        <div class="pb-2 md:mb-8">
-          <%= form.label :password, "パスワード" %>
+        <div class="pb-2 md:mb-14">
+          <%= form.label :password, "パスワード（4文字以上）" %>
           <%= form.text_field :password, class: "input input-bordered input-xs w-full form-control" %>
         </div>
 
-        <div class="text-center my-8">
-          <%= form.submit t('.login'), class: "btn btn-sm bg-primary-content w-1/4" %>
+        <div class="text-center my-8 text-thin">
+          <%= form.submit t('.login'), class: "btn btn-sm bg-primary-content w-1/3 font-thin md:font-semibold" %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
 
-<div class="container mx-auto" >
+<div class="container mx-auto mt-4 md:mt-8" >
   <div class="flex justify-center">
     <div class="flex-grow max-w-64 md:max-w-md">
       <%= form_with model: @user do |form| %>
@@ -26,7 +26,7 @@
         </div>
 
         <div class="text-center my-8">
-          <%= form.submit t('.submit'), class: "btn btn-sm bg-primary-content w-1/4" %>
+          <%= form.submit t('.submit'), class: "btn btn-sm bg-primary-content w-1/4 font-thin md:font-semibold" %>
         </div>
       <% end %>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,7 @@ ja:
       create: 登録
       submit: 保存
       update: 更新
+      post: 投稿
     label:
       email: メールアドレス
       password: パスワード
@@ -31,7 +32,6 @@ ja:
       title: 投稿一覧
     new:
       title: 投稿作成
-      submit: 投稿
     show:
       title: 投稿詳細
     edit:
@@ -52,3 +52,8 @@ ja:
     privacy_policy: プライバシーポリシー
     terms_of_service: 利用規約
     contact: お問い合わせ
+  sidebar:
+    index: Bests
+    new: Post
+    favorite: Favorite
+    search: Search

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,5 +5,34 @@ module.exports = {
     './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js'
   ],
+  theme: {
+    extend: {
+      height: {
+        'vh-5': '5vh',
+        'vh-10': '10vh',
+        'vh-50': '50vh',
+        'vh-75': '75vh',
+        'vh-100': '100vh',
+      },
+      colors: {
+        'custom-1': '#FDEDC3',
+        'custom-2': '#F2D7E7',
+        'custom-3': '#B5DBE5',
+        'custom-4': '#F6F3BE',
+        'custom-5': '#F0C4D1',
+      },
+      keyframes: {
+        flashFade: {
+          "0%": { transform: "translateY(-100px)", opacity: 1 },
+          "20%": { transform: "translateY(0)", opacity: 1 },
+          "70%": { transform: "translateY(0)", opacity: 1 },
+          "100%": { transform: "translateY(-80px)", opacity: 0 },
+        },
+      },
+      animation: {
+        flash: "flashFade 4.0s forwards",
+      },
+    },
+  },
   plugins: [require("daisyui")],
 }


### PR DESCRIPTION
サイドバーの作成/フラッシュメッセージの編集

ハンバーガーメニューを用意してクリックによるサイドバー表示/非表示切り替えという仕様で実装。
サイドバーのiconは「https://remixicon.com」を使用。headerのiconはSVG。
（fontawesomeだと細いラインのアイコンはproでしか使えなかった）

最初は画面幅が大きくなると自動でサイドバーが表示される想定だったものの、いくつか違和感の残るデザインでしか実装できなかったため断念。

断念理由
・daisyuiのコンポーネントではサイドバーが画面全体に及んでしまう。
（mainだけにスライドインさせたいのにheaderやfooterにまでサイドバーが侵食する）
・スライドインした分だけ元々表示されていたものが押し出されてしまう。
（relative使えばいける？daisyui使うことに囚われてて試してなかったかも）

フラッシュメッセージの編集
スライドイン/アウトを調べてたらフラッシュメッセージもできそうだったので実装。