### PR TITLE
アニメーションの削減

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,7 +1,7 @@
 class OauthsController < ApplicationController
   skip_before_action :require_login
   def oauth
-    #指定されたプロバイダの認証ページにユーザーをリダイレクトさせる
+    # 指定されたプロバイダの認証ページにユーザーをリダイレクトさせる
     login_at(auth_params[:provider])
   end
 
@@ -9,14 +9,14 @@ class OauthsController < ApplicationController
     provider = auth_params[:provider]
     # 既存のユーザーをプロバイダ情報を元に検索し、存在すればログイン
     if (@user = login_from(provider))
-      redirect_to root_path, notice:"#{provider.titleize}アカウントでログインしました"
+      redirect_to root_path, success: "#{provider.titleize}アカウントでログインしました"
     else
       begin
         # ユーザーが存在しない場合はプロバイダ情報を元に新規ユーザーを作成し、ログイン
         signup_and_login(provider)
-        redirect_to root_path, notice:"#{provider.titleize}アカウントでログインしました"
+        redirect_to root_path, success: "#{provider.titleize}アカウントでログインしました"
       rescue
-        redirect_to root_path, alert:"#{provider.titleize}アカウントでのログインに失敗しました"
+        redirect_to root_path, alert: "#{provider.titleize}アカウントでのログインに失敗しました"
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,5 +57,4 @@ module ApplicationHelper
       }
     }
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :reverse_of_relationships, class_name: "Relationship", foreign_key: "followee_id", dependent: :destroy
   has_many :followees, through: :relationships, source: :followee
   has_many :followers, through: :reverse_of_relationships, source: :follower
-  has_many :authentications, :dependent => :destroy
+  has_many :authentications, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 25 }
   validates :email, uniqueness: true, presence: true

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(post) %>">
-  <div class="flex flex-col h-full border border-black/50 rounded-md bg-base-100 shadow-xl hover:animate-shadow_pop_br">
+  <div class="flex flex-col h-full border border-black/50 rounded-md bg-base-100 shadow-md hover:shadow-2xl transition duration-500">
     <div class="flex flex-col items-center py-6 px-4 sm:p-6">
       <div class="flex-grow w-full">
         <div class="flex justify-between">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -2,35 +2,35 @@
   <div class="w-full h-vh-100 mt-10">
     <ul class="menu text-xl sm:text-2xl font-thin -ml-1 sm:m-6">
 
-      <li class="mb-2 sm:mb-4 hover:animate-bounce">
+      <li class="mb-2 sm:mb-4">
         <%= link_to posts_path do %>
           <i class="ri-star-line"></i>
           <%= t("sidebar.list") %>
         <% end %>
       </li>
 
-      <li class="mb-2 sm:mb-4 hover:animate-bounce">
+      <li class="mb-2 sm:mb-4">
         <%= link_to new_post_path, data: { turbo: false } do %>
           <i class="ri-pencil-line"></i>
           <%= t("sidebar.new") %>
         <% end %>
       </li>
 
-      <li class="mb-2 sm:mb-4 hover:animate-bounce">
+      <li class="mb-2 sm:mb-4">
         <%= link_to liked_posts_user_path(current_user) do %>
           <i class="ri-heart-line"></i>
           <%= t("sidebar.favorite") %>
         <% end %>
       </li>
 
-      <li class="sm:hidden mb-2 sm:mb-4 hover:animate-bounce">
+      <li class="sm:hidden mb-2 sm:mb-4">
         <%= link_to profile_path do %>
           <i class="ri-id-card-fill"></i>
           <%= t("sidebar.profile") %>
         <% end %>
       </li>
 
-      <li class="flex mb-2 sm:mb-4 hover:animate-bounce">
+      <li class="flex mb-2 sm:mb-4">
         <div class="font-thin"  onclick="my_modal_11.showModal()">
           <i class="ri-logout-box-r-line"></i>
           <span><%= t("sidebar.logout") %></span>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:external]
+Rails.application.config.sorcery.submodules = [ :external ]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -82,7 +82,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.external_providers =
   #
-  #利用する外部サービスのプロバイダーを指定
+  # 利用する外部サービスのプロバイダーを指定
   config.external_providers = %i[google]
   #
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
@@ -167,16 +167,16 @@ Rails.application.config.sorcery.configure do |config|
   # config.google.user_info_mapping = {:email => "email", :username => "name"}
   # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
   #
-  #credentials.ymlから情報を取得
+  # credentials.ymlから情報を取得
   config.google.key = Rails.application.credentials.dig(:google, :google_client_id)
   config.google.secret = Rails.application.credentials.dig(:google, :google_client_secret)
-  #API設定で承認済みのリダイレクトURIとして登録したurlを設定
+  # API設定で承認済みのリダイレクトURIとして登録したurlを設定
   if Rails.env.test?
-    config.google.callback_url = 'http://localhost:3000/test_callback'
+    config.google.callback_url = "http://localhost:3000/test_callback"
   else
     config.google.callback_url = Settings.sorcery[:google_callback_url]
   end
-  #外部サービスから取得したユーザー情報をUserモデルの指定した属性にマッピング
+  # 外部サービスから取得したユーザー情報をUserモデルの指定した属性にマッピング
   config.google.user_info_mapping = { email: "email", name: "name" }
   #
   # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.
@@ -559,7 +559,7 @@ Rails.application.config.sorcery.configure do |config|
     # Default: `nil`
     #
     # user.authentications_class =
-    #外部サービスとの認証情報を保存するモデルを指定
+    # 外部サービスとの認証情報を保存するモデルを指定
     user.authentications_class = Authentication
 
     # User's identifier in the `authentications` class.

--- a/db/migrate/20241007013817_sorcery_external.rb
+++ b/db/migrate/20241007013817_sorcery_external.rb
@@ -7,6 +7,6 @@ class SorceryExternal < ActiveRecord::Migration[7.2]
       t.timestamps              null: false
     end
 
-    add_index :authentications, [:provider, :uid]
+    add_index :authentications, [ :provider, :uid ]
   end
 end

--- a/spec/factories/authentications.rb
+++ b/spec/factories/authentications.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :authentication do
-    
   end
 end

--- a/spec/requests/oauths_spec.rb
+++ b/spec/requests/oauths_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe "Oauths", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end


### PR DESCRIPTION
アニメーションの削減
・投稿一覧でホバー時のアニメーションはカスタムアニメーションの「shadow_pop_br」を使っていたものの動作が重く感じため、ただのshadowで代用。

・サイドバーのメニューでホバー時「animate-bounce」を使っていたものの、要素の際にホバーするとホバー判定がついたり消えたり、動きが激しくなって目障りなため外す。

その他
rubocopのための修正