### PR TITLE
レイアウト調整

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -10,8 +10,8 @@
   </div>
 </div>
 
-<div class="h-full mx-auto flex flex-col" data-turbo-temporary>
-  <div class="flex justify-center h-screen sm:h-full -mt-24 sm:-mt-1">
+<div class="h-full mx-auto flex flex-col">
+  <div class="flex justify-center min-h-screen sm:h-full -mt-24 sm:-mt-1">
     <%= image_tag "top.svg", class: "z-10 w-11/12 sm:w-5/6"%>
   </div>
   <div class="contents">


### PR DESCRIPTION
## 実装内容
・TOPで最初に表示される画像を単体で画面縦中央に配置。

## 問題
・スマホの時、TOPで最初に表示される画像を単体で画面縦中央に配置するつもりで調整し、検証ツールでも問題なかったのにも関わらず、実際にスマホで確認するとレイアウトが崩れていたので修正。

## 断念・妥協・未実装
なし

## メモ